### PR TITLE
Add output and integral windup bounds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,12 @@ Metrics/BlockLength:
   ExcludedMethods:
     - context
     - describe
+
+Metrics/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.2.8
+  - 2.3.5
   - 2.4.2
 cache: bundler
 before_install: gem install bundler -v 1.16.0

--- a/lib/pid_controller.rb
+++ b/lib/pid_controller.rb
@@ -4,15 +4,42 @@ require 'pid_controller/version'
 class PidController
   attr_accessor :setpoint, :kp, :ki, :kd
 
-  def initialize(setpoint:, kp: 1.0, ki: 1.0, kd: 1.0)
+  def initialize(
+    setpoint:,
+    kp: 1.0,
+    ki: 1.0,
+    kd: 1.0,
+    integral_min: nil,
+    integral_max: nil,
+    output_min: nil,
+    output_max: nil
+  )
     @setpoint = setpoint
     @kp = kp
     @ki = ki
     @kd = kd
+    # Prevents https://en.wikipedia.org/wiki/Integral_windup via bounds
+    @integral_min = integral_min || -Float::INFINITY
+    @integral_max = integral_max || Float::INFINITY
+    @output_min = output_min || -Float::INFINITY
+    @output_max = output_max || Float::INFINITY
     @integral   = 0.0
     @derivative = 0.0
     @last_error  = nil
     @last_update = nil
+  end
+
+  unless defined?(0.clamp)
+    # Comparable#clamp is introduced in Ruby 2.4
+    module NumericClamp
+      # I'd refine Comparable itself, but older Rubies can't refine modules
+      refine Numeric do
+        def clamp(min, max)
+          [min, [max, self].min].max
+        end
+      end
+    end
+    using NumericClamp
   end
 
   def update(measurement)
@@ -32,7 +59,7 @@ class PidController
     error = setpoint - measurement.to_f
 
     if dt > 0.0
-      @integral += error * dt
+      @integral = (@integral + error * dt).clamp(@integral_min, @integral_max)
       @derivative = (error - @last_error) / dt
     end
 
@@ -42,7 +69,7 @@ class PidController
   end
 
   def output
-    p_term + i_term + d_term
+    (p_term + i_term + d_term).clamp(@output_min, @output_max)
   end
 
   def p_term
@@ -57,6 +84,7 @@ class PidController
     kd * @derivative
   end
 
+  # Read the monotonic clock. It avoid horrors of leap seconds and NTP.
   def clock_time
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end

--- a/spec/pid_controller_spec.rb
+++ b/spec/pid_controller_spec.rb
@@ -58,4 +58,28 @@ RSpec.describe PidController do
       end
     end
   end
+
+  context 'with output bounds' do
+    subject { PidController.new(setpoint: 100.0, kp: 100.0, output_min: 0.0, output_max: 1000.0) }
+    it 'checks output_min' do
+      expect(subject << 1000).to eq(0.0)
+    end
+    it 'checks output_max' do
+      expect(subject << -1000).to eq(1000.0)
+    end
+  end
+
+  context 'with integral bounds' do
+    subject { PidController.new(setpoint: 100.0, kp: 0.0, ki: 100.0, integral_min: 0.0, integral_max: 1000.0) }
+    it 'checks integral_min' do
+      expect(subject << 1000).to eq(0.0)
+      expect(subject << 1000).to eq(0.0)
+      expect(subject << 1000).to eq(0.0)
+    end
+    it 'checks integral_max' do
+      expect(subject << -1000).to eq(0.0)
+      expect(subject << -1000).to eq(100_000.0)
+      expect(subject << -1000).to eq(100_000.0)
+    end
+  end
 end


### PR DESCRIPTION
Adds parameters:

- `output_min`
- `output_max`
- `integral_min`
- `integral_max`

Integral bounds are to mitigate https://en.wikipedia.org/wiki/Integral_windup, which can happen when you are physically incapable of hitting your setpoint, or you just don't care if you're on one side of it or not.