### PR TITLE
output should not crash without measurements

### DIFF
--- a/lib/pid_controller.rb
+++ b/lib/pid_controller.rb
@@ -73,7 +73,7 @@ class PidController
   end
 
   def p_term
-    kp * @last_error
+    kp * (@last_error || 0.0)
   end
 
   def i_term

--- a/spec/pid_controller_spec.rb
+++ b/spec/pid_controller_spec.rb
@@ -59,6 +59,14 @@ RSpec.describe PidController do
     end
   end
 
+  describe '#output' do
+    context 'without any measurements' do
+      specify do
+        expect(subject.output).to eq(0.0)
+      end
+    end
+  end
+
   context 'with output bounds' do
     subject { PidController.new(setpoint: 100.0, kp: 100.0, output_min: 0.0, output_max: 1000.0) }
     it 'checks output_min' do


### PR DESCRIPTION
You may use the output or x_term methods for observability before any measurements have been setup. We shouldn't raise when this happens.