### PR TITLE
Fix update_with_duration not to TypeError

### DIFF
--- a/lib/pid_controller.rb
+++ b/lib/pid_controller.rb
@@ -60,7 +60,7 @@ class PidController
 
     if dt > 0.0
       @integral = (@integral + error * dt).clamp(@integral_min, @integral_max)
-      @derivative = (error - @last_error) / dt
+      @derivative = (error - @last_error) / dt if @last_error
     end
 
     @last_error = error

--- a/spec/pid_controller_spec.rb
+++ b/spec/pid_controller_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe PidController do
     end
   end
 
+  describe '#update_with_duration' do
+    context 'without any measurements' do
+      specify do
+        expect(subject.update_with_duration(10, 1.0)).to eq(0.0)
+      end
+    end
+  end
+
   context 'with output bounds' do
     subject { PidController.new(setpoint: 100.0, kp: 100.0, output_min: 0.0, output_max: 1000.0) }
     it 'checks output_min' do


### PR DESCRIPTION
Fixes `TypeError: nil can't be coerced into Float`. Regular `update` would pass a nil duration, eliding the calculation on the first call.